### PR TITLE
fix(gitlab): introduce displayName property to access to Gitlab projects when project name is different from the one in the URL.

### DIFF
--- a/plugins/synergy-backend/src/lib/github.ts
+++ b/plugins/synergy-backend/src/lib/github.ts
@@ -553,6 +553,8 @@ function formatProject(repo: Repository, repoTag: string): Project {
   return {
     id: repo.id,
     name: repo.name,
+    fullPath: `${repo.owner}/${repo.name}`,
+    displayName: repo.name,
     description: repo.description,
     url: repo.url,
     visibility: repo.visibility,

--- a/plugins/synergy-backend/src/lib/gitlab.ts
+++ b/plugins/synergy-backend/src/lib/gitlab.ts
@@ -23,6 +23,8 @@ class GitLabApiError extends Error {
 type GitLabProject = {
   id: string;
   name: string;
+  fullPath: string;
+  displayName: string;
   description: string;
   webUrl: string;
   visibility: string;
@@ -113,6 +115,7 @@ type GitLabResponse<T> = {
 const GITLAB_PROJECT_QUERY_BASE_FIELDS = `
   id
   name
+  fullPath
   description
   webUrl
   visibility
@@ -234,7 +237,9 @@ export async function gitlabProviderImpl({
 
     return {
       id: project.id,
-      name: project.name,
+      name: project.fullPath.replace(`${project.namespace.fullPath}/`, ''),
+      fullPath: project.fullPath,
+      displayName: project.name,
       description: project.description || '',
       url: project.webUrl,
       visibility: project.visibility,

--- a/plugins/synergy-common/src/types.ts
+++ b/plugins/synergy-common/src/types.ts
@@ -9,6 +9,8 @@ export type Contributors = {
 export type Project = {
   id: string;
   name: string;
+  fullPath: string;
+  displayName: string;
   description: string;
   url: string;
   visibility: string;

--- a/plugins/synergy/src/components/ProjectCard/ProjectCard.tsx
+++ b/plugins/synergy/src/components/ProjectCard/ProjectCard.tsx
@@ -149,8 +149,8 @@ export const ProjectCard = ({
                   <OpenInNewIcon fontSize="small" />
                 </a>
               </div>
-              <div className={styles.title} title={project.name}>
-                {project.name}
+              <div className={styles.title} title={project.displayName}>
+                {project.displayName}
               </div>
               <div className={styles.description}>
                 {project.description ?? t('projectCard.noDescription')}


### PR DESCRIPTION
 introduce displayName property to access to Gitlab projects when project name is different from the one in the URL.
![image](https://github.com/user-attachments/assets/861794bc-bd26-414d-b2a9-51d0b1c14ba2)


see: https://github.com/jiteshy/backstage-plugin-synergy/issues/24